### PR TITLE
Fix inconsistency between loss and gradient in linear regression (use…

### DIFF
--- a/src/MLC/notebooks/linear_regression_md.ipynb
+++ b/src/MLC/notebooks/linear_regression_md.ipynb
@@ -27,19 +27,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-19T19:19:47.882779Z",
+     "start_time": "2026-04-19T19:19:47.830456Z"
+    }
+   },
    "source": [
     "import numpy as np\n",
     "import random"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 1
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-19T19:19:47.898601Z",
+     "start_time": "2026-04-19T19:19:47.886784Z"
+    }
+   },
    "source": [
     "n, k, p=100, 8, 3 \n",
     "X=np.random.random([n,k])\n",
@@ -48,7 +56,9 @@
     "max_itr=1000\n",
     "alpha=0.0001\n",
     "Lambda=0.01"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 2
   },
   {
    "cell_type": "markdown",
@@ -60,9 +70,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-19T19:19:48.821568Z",
+     "start_time": "2026-04-19T19:19:48.812569Z"
+    }
+   },
    "source": [
     "# F(x)= w[0]*x + w[1]\n",
     "def F(X, W):\n",
@@ -70,17 +83,22 @@
     "\n",
     "def cost(Y_est, Y, W, Lambda):\n",
     "    E=Y_est-Y\n",
-    "    return E, np.linalg.norm(E,2)+ Lambda * np.linalg.norm(W,2)\n",
+    "    return E, np.sum(E**2)+ Lambda * np.sum(W**2)\n",
     "\n",
     "def gradient(E,X, W, Lambda):\n",
     "    return 2* np.matmul(X.T, E) + Lambda* 2* W"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 3
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-19T19:19:49.571069Z",
+     "start_time": "2026-04-19T19:19:49.557557Z"
+    }
+   },
    "source": [
     "def fit(W, X, Y, alpha, Lambda, max_itr):\n",
     "    for i in range(max_itr):\n",
@@ -93,7 +111,9 @@
     "            print(c)\n",
     "        \n",
     "    return W"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 4
   },
   {
    "cell_type": "markdown",
@@ -104,32 +124,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "34.3004759224227\n",
-      "4.265835757989014\n",
-      "4.052505749060854\n",
-      "3.8807845759072968\n",
-      "3.7422281683979812\n",
-      "3.6303399157863434\n",
-      "3.5398708528835554\n",
-      "3.4665749938168915\n",
-      "3.4070257924246747\n",
-      "3.3584711183863862\n"
-     ]
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-19T19:19:53.696191Z",
+     "start_time": "2026-04-19T19:19:53.668683Z"
     }
-   ],
+   },
    "source": [
     "X=np.concatenate( (X, np.ones((n,1))), axis=1 ) \n",
     "W=np.concatenate( (W, np.random.random((1,p)) ), axis=0 )\n",
     "\n",
     "W = fit(W, X, Y, alpha, Lambda, max_itr)"
-   ]
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "36.12367727723764\n",
+      "24.98447306141867\n",
+      "24.7012193432722\n",
+      "24.469568919452147\n",
+      "24.278540046071015\n",
+      "24.11987305387688\n",
+      "23.987270232362814\n",
+      "23.87586573984402\n",
+      "23.781852150630172\n",
+      "23.702214614741322\n"
+     ]
+    }
+   ],
+   "execution_count": 6
   },
   {
    "cell_type": "code",
@@ -148,9 +173,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python (d2l)",
    "language": "python",
-   "name": "python3"
+   "name": "d2l"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
## Fix: Inconsistency between loss function and gradient in linear regression example

Hi, thanks for this great repository!

I noticed a small inconsistency in the linear regression implementation.

### Issue

The current loss function uses:

```python
np.linalg.norm(E, 2)

Suggested Fix:
np.sum(E**2)