### PR TITLE
fix: repair broken links in ml-coding.md

### DIFF
--- a/src/MLC/ml-coding.md
+++ b/src/MLC/ml-coding.md
@@ -38,10 +38,9 @@ ML coding module may or may not exist in particular companies interviews. The go
   - tf-idf
 
 ## Other 
-  - Random int in range ([link1](https://leetcode.com/discuss/interview-question/125347/generate-uniform-random-integer
-), [link2](https://leetcode.com/articles/implement-rand10-using-rand7/))
+  - Random int in range ([link1](https://leetcode.com/discuss/interview-question/125347/generate-uniform-random-integer/), [link2](https://leetcode.com/problems/implement-rand10-using-rand7/))
   - Triangle closing 
   - Meeting point  
 
 ## Sample codes
-- You can find some sample codes under the [Notebooks]().
+- You can find some sample codes under the [Notebooks](./notebooks/).


### PR DESCRIPTION
## Summary

Fixes the broken links reported in #9 in `src/MLC/ml-coding.md`:

1. **Malformed `link1` URL** — the "Random int in range" link had an accidental newline inside the markdown syntax, causing it to render as a broken link. Fixed by putting the URL on a single line.

2. **Stale `link2` URL** — the `/articles/implement-rand10-using-rand7/` path returns 404. Updated to the canonical `/problems/implement-rand10-using-rand7/` URL.

3. **Empty `[Notebooks]()` link** — pointed nowhere. Now points to `./notebooks/` where all the sample notebooks live.

## Related Issue

Addresses #9